### PR TITLE
[43기 장지아] KakaoLogin 카카오 소셜로그인 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import KakaoLogin from './pages/KakaoLogin/KakaoLogin';
+import KakaoLoginAuth from './pages/KakaoLogin/KakaoLoginAuth';
 import Map from './pages/Map/Map';
 import Review from './pages/Review/Review';
 import Library from './pages/Library/Library';
@@ -13,6 +14,7 @@ const Router = () => {
     <BrowserRouter>
       <Routes>
         <Route path="/kakao-login" element={<KakaoLogin />} />
+        <Route path="/oauth/kakao" element={<KakaoLoginAuth />} />
         <Route path="/map" element={<Map />} />
         <Route path="/review" element={<Review />} />
         <Route path="/library" element={<Library />} />

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,2 @@
+export const CLIENT_ID = '77a14bca15191fa0698df7d6c231f011';
+export const REDIRECT_URI = 'http://localhost:3001/oauth/kakao';

--- a/src/pages/KakaoLogin/KakaoLogin.js
+++ b/src/pages/KakaoLogin/KakaoLogin.js
@@ -1,9 +1,25 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import * as S from './KakaoLogin.style';
+import { CLIENT_ID, REDIRECT_URI } from '../../config.js';
 
 const KakaoLogin = () => {
-  return <div>dsfsd</div>;
+  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+  return (
+    <S.LoginContainer>
+      <S.SplashImg src="/images/splashImg.png" alt="splashImg" />
+      <Link to={KAKAO_AUTH_URL}>
+        <S.KakaoLoginBtn
+          src="/images/kakao_login_medium_wide.png"
+          alt="kakaoLoginBtn"
+        />
+      </Link>
+      <Link to="/map">
+        <S.LookAroundBtn>로그인 없이 둘러보기</S.LookAroundBtn>
+      </Link>
+    </S.LoginContainer>
+  );
 };
 
 export default KakaoLogin;

--- a/src/pages/KakaoLogin/KakaoLogin.style.js
+++ b/src/pages/KakaoLogin/KakaoLogin.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 export const LoginContainer = styled.div`
   width: 100%;
@@ -21,4 +21,23 @@ export const LookAroundBtn = styled.div`
   font-size: 12px;
   color: white;
   text-align: center;
+`;
+
+export const rotation = keyframes`
+  from { transform: rotate(0deg) };
+  to { transform: rotate(360deg) };
+`;
+
+export const Spinner = styled.div`
+  position: absolute;
+  top: 45%;
+  left: 45%;
+  transform: translate(-50%, -50%);
+  height: 50px;
+  width: 50px;
+  border: 3px solid #9cd5c2;
+  border-radius: 50%;
+  border-top: none;
+  border-right: none;
+  animation: ${rotation} 1s linear infinite;
 `;

--- a/src/pages/KakaoLogin/KakaoLoginAuth.js
+++ b/src/pages/KakaoLogin/KakaoLoginAuth.js
@@ -1,0 +1,59 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as S from './KakaoLogin.style';
+import { CLIENT_ID, REDIRECT_URI } from '../../config.js';
+
+const KakaoLoginAuth = () => {
+  const navigate = useNavigate();
+  const KAKAO_CODE = new URL(window.location.href).search.split('=')[1];
+
+  useEffect(() => {
+    fetch(
+      `https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&code=${KAKAO_CODE}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }
+    )
+      .then(res => res.json())
+      .then(data => {
+        console.log(`data.access_token: ${data.access_token}`);
+        if (data.access_token) {
+          // localStorage.setItem('token', data.access_token);
+          // navigate('/map');
+          fetch('http://10.58.52.145:3001/users/kakao', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json;charset=utf-8',
+              authorization: data.access_token,
+            },
+          })
+            .then(res => res.json())
+            .then(list => {
+              console.log(`list.accessToken: ${list.accessToken}`);
+              if (list.accessToken) {
+                localStorage.setItem('token', list.accessToken);
+                navigate('/placelist');
+              } else {
+                alert('로그인에 실패했습니다.');
+                localStorage.removeItem('token', list.accessToken);
+                navigate('/kakao-login');
+              }
+            });
+        } else {
+          alert('로그인에 실패했습니다.');
+          navigate('/kakao-login');
+        }
+      });
+  }, []);
+
+  return (
+    <div>
+      <S.Spinner />
+    </div>
+  );
+};
+
+export default KakaoLoginAuth;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜로그인 기능 구현
- 선택동의 미선택시 alert 및 재로그인 유도

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 소셜로그인 기능 구현
- 백엔드와 소셜로그인 테스트 완료 

2. 선택동의 미선택시 alert 및 재로그인 유도 -> 추가구현으로 변경
- 이메일 및 성별을 필수적으로 수집해야 하는데, 카카오 어플리케이션에서 비즈프로필로 심사 후 통과되어야만 해당 부분을 필수 항목으로 변경할 수 있어 규정을 바꿀 수는 없었음
- 따라서 카카오측 설정에서는 선택으로 남겨놓되, 사용자가 해당 부분을 미선택한 채로 로그인을 시도할 시 alert으로 '선택 동의를 확인해주세요'를 띄운 후 로그인 화면으로 다시 redirect 시키고자 함
- 재로그인 불가한 문제가 발생했으나 백엔드가 해결해야 하는 문제이기에 해당 부분 추가 구현으로 변경하기로 합의
-> 프론트 측에서 저장한 액세스 토큰을 삭제시킨 후 사용자를 다시 로그인시키려고 했으나 계속해서 로그인 기록이 남아있어 재로그인이 안되는 문제 발생 
-> 공식문서에 따르면 우리가 직접 '연결 끊기'를 진행해야 하는데, 이 경우 admin key라는 중요한 정보를 활용해야 해서 백엔드가 진행해야 한다고 함 
-> 백엔드에서 해당 부분 구현까지 시간이 다소 걸릴 것 같다고 했기에 추가 구현으로 변경하기로 합의한 상황

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 소셜로그인의 전반적인 과정에 대해 직접 구현하면서 익힐 수 있었습니다.
- 기존 로그인과 달리 승인의 또 다른 주체가 있는 로그인 방식을 진행하면서 제 3자가 개입하는 프로세스에 대해 접할 수 있었습니다.
- 사용자 정보를 삭제하는 부분과 같이 중요한 정보를 다루는 작업은 백엔드와 논의해야 하는 사항인데 프론트엔드에서 처리할 수 있는 작업인 줄 알고 시간을 많이 끌었던 것 같습니다. 다음 번에는 백엔드와 소통을 더 많이 하고, 백엔드쪽 공식문서도 확인해가면서 진행할 필요가 있다는 걸 깨달았습니다!

<br />

## :: 기타 질문 및 특이 사항
- 위에도 작성했지만, 선택 동의사항 처리는 추가 구현으로 변경한 상황입니다. 해당 PR은 카카오 소셜로그인의 기본 기능만을 구현한 작업 내역입니다. 참고 부탁드립니다!
